### PR TITLE
Address route returns object

### DIFF
--- a/app/enums.py
+++ b/app/enums.py
@@ -18,3 +18,15 @@ class EventType(Enum):
     lorem_paragraphs_break = auto()
     lorem_lists = auto()
     uuid = auto()
+
+
+@unique
+class ProviderType(Enum):
+    address = auto()
+    person = auto()
+
+
+@unique
+class Locale(Enum):
+    en = 'en'
+    ru = 'ru'

--- a/app/helpers/factory.py
+++ b/app/helpers/factory.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import functools
 
-from enums import ProviderType
+from app.enums import ProviderType
 from mimesis import Address
 
 

--- a/app/helpers/factory.py
+++ b/app/helpers/factory.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+import functools
+
+from enums import ProviderType
+from mimesis import Address
+
+
+class ProviderFactory:
+
+    @staticmethod
+    @functools.lru_cache
+    def get(provider_type: ProviderType, lang: str = 'en'):
+        match provider_type:
+            case ProviderType.address:
+                return Address(lang)

--- a/app/middlewares.py
+++ b/app/middlewares.py
@@ -1,19 +1,17 @@
 #!/usr/bin/env python
 from http import HTTPStatus
 
+from enums import Locale
 from fastapi import HTTPException
 from starlette.requests import Request
 
-from .responses.address import MIMESIS_LANGUAGES
 
-
-async def verify_mimesis_locales(request: Request):
+async def verify_locale(request: Request):
     """
-    Used as middleware for all requests to check if requested url path is in allowed set
-
-    :param request: Starlette.requests.Request object
+    Used as middleware for the requests to check if requested URL path is in allowed set
     """
-    if (request.path_params['lang']
-            and request.path_params['lang']) not in MIMESIS_LANGUAGES.keys():
 
+    allowed_locales: list[str] = [_.value for _ in Locale]
+
+    if (request.path_params['lang'] and request.path_params['lang']) not in allowed_locales:
         raise HTTPException(status_code=HTTPStatus.BAD_REQUEST, detail='Incorrect locale')

--- a/app/middlewares.py
+++ b/app/middlewares.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 from http import HTTPStatus
 
-from enums import Locale
+from app.enums import Locale
 from fastapi import HTTPException
 from starlette.requests import Request
 

--- a/app/models/schema/address.py
+++ b/app/models/schema/address.py
@@ -1,22 +1,21 @@
 #!/usr/bin/env python
-from typing import Union
-
 from pydantic import BaseModel
 
 
 class AddressSchema(BaseModel):
     address: str
-    calling_code: str
+    calling_code: int
     city: str
     continent: str
-    coordinates: dict
+    coordinates: dict[str, float]
     country: str
     country_code: str
-    latitude: Union[str, float]
-    longitude: Union[str, float]
-    postal_code: str
     state: str
     street_name: str
-    street_number: str
+    street_number: int
     street_suffix: str
     zip_code: str
+
+
+class RootAddressSchema(BaseModel):
+    result: list[AddressSchema] = []

--- a/app/responses/address.py
+++ b/app/responses/address.py
@@ -1,40 +1,41 @@
 #!/usr/bin/env python
-# This module is wrapper for Mimesis's address provider
-# Map Mimesis languages like "locale": "country_code"
-import functools
+from enums import ProviderType
+from helpers.factory import ProviderFactory
 
-from mimesis import Address
-
-MIMESIS_LANGUAGES = {
-    'en': 'us',
-    'ru': 'ru'
-}
+from app.models.schema.address import AddressSchema
+from app.responses.response import Response
 
 
-@functools.lru_cache()
-def get_address_object(lang: str) -> Address:
-    return Address(lang)
+class AddressResponse(Response):
+    def __init__(self, lang: str, **kwargs):
+        self.lang = lang
+        self.provider = ProviderFactory.get(ProviderType.address, lang=lang)
+        self.address = kwargs['address']
+        self.calling_code = kwargs['calling_code']
+        self.city = kwargs['city']
+        self.continent = kwargs['continent']
+        self.country = kwargs['country']
+        self.country_code = kwargs['country_code']
+        self.state = kwargs['state']
+        self.street_name = kwargs['street_name']
+        self.street_number = kwargs['street_number']
+        self.street_suffix = kwargs['street_suffix']
+        self.zip_code = kwargs['zip_code']
 
-
-def get_data(address: Address, lang: str):
-    return {
-        'address': address.address(),
-        'calling_code': address.calling_code(),
-        'city': address.city(),
-        'continent': address.continent(),
-        'coordinates': address.coordinates(),
-        'country': address.country(),
-        'country_code': get_country_code(lang),
-        'latitude': address.latitude(),
-        'longitude': address.longitude(),
-        'postal_code': address.postal_code(),
-        'state': address.state(),
-        'street_name': address.street_name(),
-        'street_number': address.street_number(),
-        'street_suffix': address.street_suffix(),
-        'zip_code': address.zip_code()
-    }
-
-
-def get_country_code(language: str) -> str:
-    return MIMESIS_LANGUAGES[language]
+    def generate(self):
+        return AddressSchema(
+            address=self.address or self.provider.address(),
+            calling_code=self.calling_code or self.provider.calling_code(),
+            city=self.city or self.provider.city(),
+            continent=self.continent or self.provider.continent(),
+            coordinates=self.provider.coordinates(),
+            country=self.country or self.provider.country(),
+            country_code=self.country_code or self.provider.country_code(),
+            latitude=self.provider.latitude(),
+            longitude=self.provider.longitude(),
+            state=self.state or self.provider.state(),
+            street_name=self.street_name or self.provider.street_name(),
+            street_number=self.street_number or self.provider.street_number(),
+            street_suffix=self.street_suffix or self.provider.street_suffix(),
+            zip_code=self.zip_code or self.provider.zip_code()
+        )

--- a/app/responses/address.py
+++ b/app/responses/address.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-from enums import ProviderType
-from helpers.factory import ProviderFactory
+from app.enums import ProviderType
+from app.helpers.factory import ProviderFactory
 
 from app.models.schema.address import AddressSchema
 from app.responses.response import Response

--- a/app/routers/address.py
+++ b/app/routers/address.py
@@ -1,24 +1,48 @@
 #!/usr/bin/env python
 from fastapi import APIRouter
 from fastapi import Depends
-from mimesis import Address
 
 from app.enums import EventType
-from app.middlewares import verify_mimesis_locales
-from app.models.schema.address import AddressSchema
-from app.responses.address import get_address_object
-from app.responses.address import get_data
 from app.helpers.event import Event
+from app.middlewares import verify_locale
+from app.models.schema.address import RootAddressSchema
+from app.responses.address import AddressResponse
 
 router = APIRouter()
 
 
-@router.get('/{lang}/address',
-            dependencies=[Depends(verify_mimesis_locales)])
-async def get_address(lang: str):
-    address: Address = get_address_object(lang)
-    data = get_data(address, lang)
+@router.get('/{lang}/address', dependencies=[Depends(verify_locale)])
+async def get_address(lang: str,
+                      address: str | None = None,
+                      calling_code: int | None = None,
+                      city: str | None = None,
+                      continent: str | None = None,
+                      country: str | None = None,
+                      country_code: str | None = None,
+                      state: str | None = None,
+                      street_name: str | None = None,
+                      street_number: str | None = None,
+                      street_suffix: str | None = None,
+                      zip_code: int | str | None = None,
+                      count: int = 1):
+
+    address_response: AddressResponse = AddressResponse(lang=lang,
+                                                        address=address,
+                                                        calling_code=calling_code,
+                                                        city=city,
+                                                        continent=continent,
+                                                        country=country,
+                                                        country_code=country_code,
+                                                        state=state,
+                                                        street_name=street_name,
+                                                        street_number=street_number,
+                                                        street_suffix=street_suffix,
+                                                        zip_code=zip_code)
+
+    responses = []
+    if count >= 1:
+        for _ in range(count):
+            responses.append(address_response.generate())
 
     await Event.send_event(event_type=EventType.address, language=lang)
-
-    return AddressSchema(**data)
+    return RootAddressSchema(result=responses)

--- a/app/routers/person.py
+++ b/app/routers/person.py
@@ -4,19 +4,18 @@ from fastapi import Depends
 from mimesis import Person
 
 from app.enums import EventType
-from app.middlewares import verify_mimesis_locales
+from app.helpers.event import Event
+from app.middlewares import verify_locale
 from app.models.schema.person import PersonSchema
 from app.responses.person import get_additional_data
 from app.responses.person import get_data
 from app.responses.person import get_person_gender
 from app.responses.person import get_person_object
-from app.helpers.event import Event
 
 router = APIRouter()
 
 
-@router.get('/{lang}/person',
-            dependencies=[Depends(verify_mimesis_locales)],
+@router.get('/{lang}/person', dependencies=[Depends(verify_locale)],
             response_model=PersonSchema,
             response_model_exclude_none=True)
 async def get_person(lang: str):

--- a/app/routers/uuid.py
+++ b/app/routers/uuid.py
@@ -5,10 +5,10 @@ from fastapi import APIRouter
 from fastapi import HTTPException
 
 from app.enums import EventType
+from app.helpers.event import Event
 from app.models.schema.uuid import RootUuidSchema
 from app.models.schema.uuid import UuidSchema
 from app.responses.uuid import UuidResponse
-from app.helpers.event import Event
 
 router = APIRouter()
 

--- a/tests/test_address_router.py
+++ b/tests/test_address_router.py
@@ -1,62 +1,54 @@
 #!/usr/bin/env python
 from requests import Response
 
-from app.responses.address import get_country_code
-
-EN_LOCALE_COUNTRY_CODE = 'us'
-RU_LOCALE_COUNTRY_CODE = 'ru'
+RESPONSE_STRUCTURE = {
+        'result': [
+            {
+                'address': '',
+                'calling_code': '',
+                'city': '',
+                'continent': '',
+                'coordinates': '',
+                'country': '',
+                'country_code': '',
+                'state': '',
+                'street_name': '',
+                'street_number': '',
+                'street_suffix': '',
+                'zip_code': '',
+            }
+        ]
+    }
 
 
 def test_en_address_router(client, setup_test_db):
     with client:
         response: Response = client.get('/v1/en/address')
 
-    response_structure = {
-        'address': '',
-        'calling_code': '',
-        'city': '',
-        'continent': '',
-        'coordinates': '',
-        'country': '',
-        'country_code': get_country_code(language='en') == EN_LOCALE_COUNTRY_CODE,
-        'latitude': '',
-        'longitude': '',
-        'postal_code': '',
-        'state': '',
-        'street_name': '',
-        'street_number': '',
-        'street_suffix': '',
-        'zip_code': '',
-    }
-
-    assert response.status_code == 200
-    assert response_structure.keys() == response.json().keys()
+    ensure_valid_response(response)
 
 
 def test_ru_address_router(client):
     with client:
         response: Response = client.get('/v1/ru/address')
 
-    response_structure = {
-        'address': '',
-        'calling_code': '',
-        'city': '',
-        'continent': '',
-        'coordinates': '',
-        'country': '',
-        'country_code': get_country_code(language='ru') == RU_LOCALE_COUNTRY_CODE,
-        'latitude': '',
-        'longitude': '',
-        'postal_code': '',
-        'state': '',
-        'street_name': '',
-        'street_number': '',
-        'street_suffix': '',
-        'zip_code': '',
-    }
+    ensure_valid_response(response)
 
-    assert response.status_code == 200
-    assert response_structure.keys() == response.json().keys()
+
+def test_en_address_count_param(client):
+    with client:
+        response: Response = client.get('/v1/en/address?count=2')
+
+    ensure_valid_response(response)
+    assert len(response.json()['result']) == 2
+
+
+def test_ru_address_count_param(client):
+    with client:
+        response: Response = client.get('/v1/ru/address?count=2')
+
+    ensure_valid_response(response)
+    assert len(response.json()['result']) == 2
 
 
 def test_incorrect_locale(client):
@@ -71,3 +63,8 @@ def test_inexistent_route(client):
         response: Response = client.get('/v1/en/no_route')
 
     assert response.status_code == 404
+
+
+def ensure_valid_response(response: Response):
+    assert response.status_code == 200
+    assert RESPONSE_STRUCTURE.keys() == response.json().keys()


### PR DESCRIPTION
## New response structure and data
This PR changes response structure to the following:
```json
{
  "result": [
    {
      "address": "199 Liberty Row",
      "calling_code": 237,
      "city": "Portland",
      "continent": "Europe",
      "coordinates": {
        "longitude": 140.098683,
        "latitude": -2.313105
      },
      "country": "Indonesia",
      "country_code": "TT",
      "state": "Iowa",
      "street_name": "Burns",
      "street_number": 936,
      "street_suffix": "Square",
      "zip_code": "96785"
    }
  ]
}
```

Currently, the generated data is fully random, so there is no any consistence there. For example, `continent` could be Africa but `zip_code` from the USA.

## New query parameters

I just added these optional parameters (without any length validation):
1. `address`
2. `calling_code`
3. `city`
4. `continent`
5. `country`
6. `country_code`
7. `state`
8. `street_name`
9. `street_number`
10. `street_suffix`
11. `zip_code`

So, it's possible to generate request URL like this:
`/v1/en/person?address=Example+St.&country=Example+Country&zip_code=10EXAMPL`

The response will be like this:
```json
{
  "result": [
    {
      "address": "Example St.",
      "calling_code": 383,
      "city": "Santee",
      "continent": "Antarctica",
      "coordinates": {
        "longitude": 0.931864,
        "latitude": 80.503004
      },
      "country": "Example Country",
      "country_code": "SD",
      "state": "Arizona",
      "street_name": "San Juan",
      "street_number": 1288,
      "street_suffix": "Viaduct",
      "zip_code": "10EXMPL20"
    }
  ]
}
```

There is an additional `count` parameter which will produce a selected amount of data.

Closes #256