### PR TITLE
Add `seed` param to routes

### DIFF
--- a/app/helpers/factory.py
+++ b/app/helpers/factory.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import functools
+import random
 
 from mimesis import Address
 from mimesis import Person
@@ -9,18 +10,24 @@ from app.enums import Locale
 from app.enums import ProviderType
 
 
-class ProviderFactory:
+class Factory:
 
     @staticmethod
     @functools.lru_cache
-    def get(provider_type: ProviderType, locale: Locale = Locale.EN):
+    def get_provider(provider_type: ProviderType, seed: str = None, locale: Locale = Locale.EN):
 
         _locale: str = locale.value
 
         match provider_type.value:
             case ProviderType.ADDRESS.value:
-                return Address(_locale)
+                return Address(_locale, seed=seed)
             case ProviderType.PERSON.value:
-                return Person(_locale)
+                return Person(_locale, seed=seed)
             case ProviderType.REGIONAL_RU.value:
-                return RussiaSpecProvider()
+                return RussiaSpecProvider(seed=seed)
+
+    @staticmethod
+    @functools.lru_cache
+    def get_gender_code(seed):
+        random.seed(seed)
+        return random.choice([1, 2])

--- a/app/models/schema/address.py
+++ b/app/models/schema/address.py
@@ -19,3 +19,4 @@ class AddressSchema(BaseModel):
 
 class RootAddressSchema(BaseModel):
     result: list[AddressSchema] = []
+    seed: str | None

--- a/app/models/schema/person.py
+++ b/app/models/schema/person.py
@@ -31,3 +31,4 @@ class PersonSchema(BaseModel):
 
 class RootPersonSchema(BaseModel):
     result: list[PersonSchema] = []
+    seed: str = None

--- a/app/responses/address.py
+++ b/app/responses/address.py
@@ -1,15 +1,18 @@
 #!/usr/bin/env python
+from mimesis import Address
+
 from app.enums import Locale
 from app.enums import ProviderType
-from app.helpers.factory import ProviderFactory
+from app.helpers.factory import Factory
 from app.models.schema.address import AddressSchema
 from app.responses.response import Response
 
 
 class AddressResponse(Response):
-    def __init__(self, locale: str, **kwargs):
+    def __init__(self, locale: str, seed: str, **kwargs):
         self.locale = Locale[locale.upper()]
-        self.provider = ProviderFactory.get(ProviderType.ADDRESS, locale=self.locale)
+        self.seed = seed
+        self.provider: Address = Factory.get_provider(ProviderType.ADDRESS, locale=self.locale, seed=self.seed)
         self.address = kwargs['address']
         self.calling_code = kwargs['calling_code']
         self.city = kwargs['city']
@@ -23,6 +26,8 @@ class AddressResponse(Response):
         self.zip_code = kwargs['zip_code']
 
     def generate(self):
+        self.provider.reseed(self.seed)
+
         return AddressSchema(
             address=self.address or self.provider.address(),
             calling_code=self.calling_code or self.provider.calling_code(),

--- a/tests/test_address_router.py
+++ b/tests/test_address_router.py
@@ -2,23 +2,24 @@
 from requests import Response
 
 RESPONSE_STRUCTURE = {
-        'result': [
-            {
-                'address': '',
-                'calling_code': '',
-                'city': '',
-                'continent': '',
-                'coordinates': '',
-                'country': '',
-                'country_code': '',
-                'state': '',
-                'street_name': '',
-                'street_number': '',
-                'street_suffix': '',
-                'zip_code': '',
-            }
-        ]
-    }
+    'result': [
+        {
+            'address': '',
+            'calling_code': '',
+            'city': '',
+            'continent': '',
+            'coordinates': '',
+            'country': '',
+            'country_code': '',
+            'state': '',
+            'street_name': '',
+            'street_number': '',
+            'street_suffix': '',
+            'zip_code': '',
+        }
+    ],
+    'seed': ''
+}
 
 
 def test_en_address_router(client, setup_test_db):

--- a/tests/test_person_router.py
+++ b/tests/test_person_router.py
@@ -23,7 +23,8 @@ RESPONSE_STRUCTURE = {
             'weight': '',
             'work_experience': ''
         }
-    ]
+    ],
+    'seed': ''
 }
 
 


### PR DESCRIPTION
# What's changed

## New `seed` parameter
This PR changes response structure to the following:
```json
{
  "result": [
    {
        ...
    }
  ],
  "seed": "random_seed"
}
```

This parameter allows producing the same data as it was generated early.

Closes #260